### PR TITLE
Create MNIST C dataset

### DIFF
--- a/src/rai_toolbox/datasets/__init__.py
+++ b/src/rai_toolbox/datasets/__init__.py
@@ -5,6 +5,7 @@
 from ._imagenet_base import ImageNet, ImageNetM10, RestrictedImageNet
 from .cifar10_extensions import CIFAR10P1
 from .cifar_corruptions import CIFAR10C, CIFAR100C
+from .mnist_corruptions_kes import MNISTC
 
 __all__ = [
     "CIFAR10C",
@@ -13,4 +14,5 @@ __all__ = [
     "ImageNet",
     "ImageNetM10",
     "RestrictedImageNet",
+    "MNISTC"
 ]

--- a/src/rai_toolbox/datasets/__init__.py
+++ b/src/rai_toolbox/datasets/__init__.py
@@ -16,5 +16,5 @@ __all__ = [
     "ImageNet",
     "ImageNetM10",
     "RestrictedImageNet",
-    "MNISTC"
+    "MNISTC",
 ]

--- a/src/rai_toolbox/datasets/__init__.py
+++ b/src/rai_toolbox/datasets/__init__.py
@@ -7,6 +7,8 @@ from .cifar10_extensions import CIFAR10P1
 from .cifar_corruptions import CIFAR10C, CIFAR100C
 from .mnist_corruptions_kes import MNISTC
 
+# TODO: fix package errors and remove kes identifier in package file
+
 __all__ = [
     "CIFAR10C",
     "CIFAR100C",

--- a/src/rai_toolbox/datasets/mnist_corruptions_kes.py
+++ b/src/rai_toolbox/datasets/mnist_corruptions_kes.py
@@ -236,8 +236,16 @@ class MNISTC(VisionDataset):
 # TODO: get rid of this testing code
 print('\n\n')
 mnistc = MNISTC("data", "dotted_line", "combined", None, None, True)
-img, target = mnistc.__getitem__(5)
+img, target = mnistc[5]
+print(mnistc.__len__())
 
 from torch.utils.data import DataLoader, random_split
-mnistc_dataloader = DataLoader(mnistc, batch_size=64)
-print(mnistc.__len__())
+from math import floor
+split_percent = 0.9
+d1_size = floor(mnistc.__len__() * split_percent)
+d2_size = mnistc.__len__() - d1_size
+d1, d2 = random_split(mnistc, [d1_size, d2_size])
+mnistc_train_dataloader = DataLoader(d1, batch_size=64)
+mnistc_test_dataloader = DataLoader(d2, batch_size=64)
+print(d1.__len__())
+print(d2.__len__())

--- a/src/rai_toolbox/datasets/mnist_corruptions_kes.py
+++ b/src/rai_toolbox/datasets/mnist_corruptions_kes.py
@@ -8,13 +8,13 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Tuple, Union
 
 # TODO: fix this to use package import from __init__.py
+# from ._utils import md5_check
 import _utils
 import numpy as np
 from PIL import Image
 from torch.utils.data import DataLoader, random_split
 from torchvision.datasets.utils import download_and_extract_archive
 from torchvision.datasets.vision import VisionDataset
-from torchvision.transforms import ToPILImage
 from typing_extensions import Literal
 
 __all__ = ["MNISTC"]
@@ -168,6 +168,7 @@ class MNISTC(VisionDataset):
         zip_path = Path.joinpath(root_path, self.filename)
 
         if Path.is_file(zip_path):
+            # TODO: change back when package errors are resolved
             zip_md5_check = _utils.md5_check(zip_path) == self.zip_md5
             if not zip_md5_check:
                 return False
@@ -212,8 +213,9 @@ class MNISTC(VisionDataset):
         img, target = self.data[index], self.targets[index]
 
         # doing this so that it is consistent with all other datasets
-        # to return a PIL Image
-        img = ToPILImage(img)
+        # to return a PIL Image -- need to drop last dimension to
+        # properly import using PIL
+        img = Image.fromarray(img[:, :, 0])
 
         if self.transform is not None:
             img = self.transform(img)
@@ -249,3 +251,4 @@ mnistc_train_dataloader = DataLoader(d1, batch_size=64)
 mnistc_test_dataloader = DataLoader(d2, batch_size=64)
 print(d1.__len__())
 print(d2.__len__())
+MNISTC["birds"]

--- a/src/rai_toolbox/datasets/mnist_corruptions_kes.py
+++ b/src/rai_toolbox/datasets/mnist_corruptions_kes.py
@@ -1,0 +1,243 @@
+# Copyright 2022, MASSACHUSETTS INSTITUTE OF TECHNOLOGY
+# Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from typing import Any, Callable, Optional, Union, Tuple
+from typing_extensions import Literal
+
+import hashlib
+import numpy as np
+from PIL import Image
+from torchvision.transforms import ToPILImage
+from torchvision.datasets.utils import download_and_extract_archive
+from torchvision.datasets.vision import VisionDataset
+
+# TODO: fix this to use package import from __init__.py
+import _utils
+
+__all__ = ["MNISTC"]
+
+# typing hints
+PathLike = Union[str, Path]
+Corruptions = Literal[
+    "brightness",
+    "canny_edges",
+    "dotted_line",
+    "fog",
+    "glass_blur",
+    "identity",
+    "impulse_noise",
+    "motion_blur",
+    "rotate",
+    "scale",
+    "shear",
+    "shot_noise",
+    "spatter",
+    "stripe",
+    "translate",
+    "zigzag",
+]
+Groupings = Literal[
+    "train",
+    "test",
+    "combined"
+]
+
+class MNISTC(VisionDataset):
+
+    url = "https://zenodo.org/record/3239543/files/mnist_c.zip"
+    filename = "mnist_c.zip"
+    zip_md5: str = "4b34b33045869ee6d424616cd3a65da3"
+    files_md5: str = "d2bff22ed798fda041f7a54c096a1a2b"
+    base_folder: str = "MNISTC"
+
+    all_corruptions = (
+        "brightness",
+        "canny_edges",
+        "dotted_line",
+        "fog",
+        "glass_blur",
+        "identity",
+        "impulse_noise",
+        "motion_blur",
+        "rotate",
+        "scale",
+        "shear",
+        "shot_noise",
+        "spatter",
+        "stripe",
+        "translate",
+        "zigzag",
+    )
+
+    all_groupings = (
+        "train",
+        "test",
+        "combined"
+    )
+
+    def __init__(
+        self,
+        root: PathLike,
+        corruption: Corruptions,
+        grouping: Groupings,
+        transform: Optional[Callable[[Image.Image], Any]] = None,
+        target_transform: Optional[Callable[[int], Any]] = None,
+        download: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        root : PathLike
+            Root directory of dataset where directory
+            ``MNISTC`` exists or will be saved to if download is set to True.
+
+        corruption : str
+            The type of corruption, e.g., "fog". See `MNISTC.all_corruptions()` for a full list of corruptions.
+
+        grouping : str
+            The type of grouping for the dataset: "train", "test", or "combined".
+
+        transform :  Optional[Callable[[Image], Any]]
+            A function/transform that takes in a PIL image
+            and returns a transformed version. E.g., ``transforms.RandomCrop``
+
+        target_transform : Optional[Callable]
+            A function/transform that takes in a target
+            and returns a transformed version.
+
+        download : bool, optional (default=False)
+            If true, downloads the dataset from the internet and puts it in root directory.
+            If dataset is already downloaded, it is not downloaded again."""
+        super().__init__(
+            root=str(root), transform=transform, target_transform=target_transform
+        )
+
+        # TODO: check to see how using _root below in downloader affects torchvision root in base class
+        self._root = (Path(self.root) / self.base_folder).resolve()
+        assert corruption in self.all_corruptions,f"The corruption '{corruption}' is invalid"
+        self.corruption = corruption
+
+        assert grouping in self.all_groupings,f"The grouping '{grouping}' is invalid: valid choices" \
+            " are 'train', 'test', or 'combined'"
+        self.grouping = grouping
+
+        if download:
+            self.download()
+
+
+        if not self._check_integrity():
+            raise RuntimeError(
+                "Dataset not found or corrupted."
+                + " You can use download=True to download it"
+            )
+
+        
+        if self.grouping == "test" or self.grouping == "combined":
+            test_images_path = Path.joinpath(self._root, "mnist_c", corruption, "test_images.npy")
+            test_labels_path = Path.joinpath(self._root, "mnist_c", corruption, "test_labels.npy")
+            mmap_test = np.load(test_images_path, mmap_mode="r")
+            test_target = np.load(test_labels_path)
+
+        if self.grouping == "train" or self.grouping == "combined":
+            train_images_path = Path.joinpath(self._root, "mnist_c", corruption, "train_images.npy")
+            train_labels_path = Path.joinpath(self._root, "mnist_c", corruption, "train_labels.npy")
+            mmap_train = np.load(train_images_path, mmap_mode="r")
+            train_target = np.load(train_labels_path)
+
+        # shape-(N, H, W, C)
+        if self.grouping == "train":
+            self.data = mmap_train
+            self.targets = train_target
+        elif self.grouping == "test":
+            self.data = mmap_test
+            self.targets = test_target
+        elif self.grouping == "combined":
+            self.data = np.concatenate((mmap_test, mmap_train))
+            self.targets = np.concatenate((test_target, train_target))
+        else:
+            raise RuntimeError(f"Unknown grouping: {self.grouping}")
+
+    
+    def _check_integrity(self) -> bool:
+        root_path = Path(self._root)
+        zip_path = Path.joinpath(root_path, self.filename)
+
+        if Path.is_file(zip_path):
+            zip_md5_check = _utils.md5_check(zip_path) == self.zip_md5
+            if not zip_md5_check:
+                return False
+
+        files_to_checksum = []
+
+        for file in Path.glob(root_path, "mnist_c/**/*"):
+            if not file.is_file():
+                continue
+            files_to_checksum.append(file)
+                
+        # sort the file paths to make MD5 deterministic        
+        files_to_checksum.sort()
+        hash_md5 = hashlib.md5()
+
+        for file in files_to_checksum:
+            # not using package .util hasher since this is
+            # hashing over several files and needs to keep state
+            # between files
+            chunksize: int = 1024 ** 2
+            with open(file, "rb") as f:
+                for chunk in iter(lambda: f.read(chunksize), b""):
+                    hash_md5.update(chunk)
+        
+        if hash_md5.hexdigest() != self.files_md5:
+            return False
+
+        return True
+
+    def __getitem__(self, index: int) -> Tuple[Any, Any]:
+        """
+        Parameters
+        ----------
+        index: int
+
+        Returns
+        -------
+        Tuple
+            (transform(image), target_transform(target)) where
+            target is the index of the target class.
+        """
+        img, target = self.data[index], self.targets[index]
+
+        # doing this so that it is consistent with all other datasets
+        # to return a PIL Image
+        img = ToPILImage(img)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+    
+    def __len__(self) -> int:
+        return len(self.data)
+
+        
+    def download(self) -> None:
+        if self._check_integrity():
+            print("Files already downloaded and verified")
+            return
+        download_and_extract_archive(
+            self.url, self._root, filename=self.filename, md5=self.zip_md5
+        )
+
+
+# TODO: get rid of this testing code
+print('\n\n')
+mnistc = MNISTC("data", "dotted_line", "combined", None, None, True)
+img, target = mnistc.__getitem__(5)
+
+from torch.utils.data import DataLoader, random_split
+mnistc_dataloader = DataLoader(mnistc, batch_size=64)
+print(mnistc.__len__())


### PR DESCRIPTION
This creates a new dataset class that loads the MNIST corrupted dataset from [MNIST-C: A Robustness Benchmark for Computer Vision](https://zenodo.org/record/3239543#.YqD-fqjMIuU). The MNIST-C dataset supports 15 different corruptions to the original MNIST dataset (e.g., brightness, fog, scale, rotate) and is separated into testing and training sets.